### PR TITLE
Improve newline regex to accept old mac files

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ Gedcom.prototype._setStreamUnwritable = function () {
 };
 
 Gedcom.prototype._splitBufferByNewlines = function () {
-  return this._buffer.split(/\r?\n/);
+  return this._buffer.split(/\r\n|\r|\n/);
 };
 
 module.exports = Gedcom;


### PR DESCRIPTION
This seems prudent since gedcom files can come from older mac programs (like reunion)
